### PR TITLE
QoL + calculate features

### DIFF
--- a/swtools/app/components/navbar/NavBarProfile.tsx
+++ b/swtools/app/components/navbar/NavBarProfile.tsx
@@ -37,7 +37,7 @@ const NavBarProfile: React.FC<NavBarProfileProps> = ({ mobile = false }) => {
 		<div className={`relative float-right ml-auto ${mobile ? "block lg:hidden" : "hidden lg:block"}`} ref={dropdownRef}>
 			<button
 				type="button"
-				className="p-2 rounded-md text-[var(--foreground)] font-montserrat font-[700] animate-press focus:outline-none"
+				className="p-2 rounded-md text-[var(--foreground)] font-montserrat font-[700] animate-press focus:outline-none cursor-pointer"
 				onClick={() => setOpen((prev) => !prev)}
 				aria-haspopup="true"
 				aria-expanded={open}
@@ -58,7 +58,7 @@ const NavBarProfile: React.FC<NavBarProfileProps> = ({ mobile = false }) => {
 				)}
 			</button>
 			{open && (
-				<div className="absolute right-0 w-48 bg-content rounded shadow-lg z-50">
+				<div className="absolute right-0 w-48 bg-content rounded shadow-lg z-50 cursor-pointer">
 					{user ? (
 						<Link href="/auth/profile" className="block px-4 py-2 text-white" onClick={() => setOpen(false)}>
 							Profile

--- a/swtools/app/components/player/PlayerExtraInfo.tsx
+++ b/swtools/app/components/player/PlayerExtraInfo.tsx
@@ -17,6 +17,17 @@ const socials = {
 	HYPIXEL: "/icons/hypixel.png",
 };
 
+const linkPrefixes = {
+	TWITTER: "https://twitter.com/",
+	YOUTUBE: "",
+	INSTAGRAM: "https://www.instagram.com/",
+	TIKTOK: "https://www.tiktok.com/@",
+	TWITCH: "https://www.twitch.tv/",
+	DISCORD: "https://discord.com/users/",
+	HYPIXEL: "",
+
+}
+
 const PlayerExtraInfo: React.FC<PlayerExtraInfoProps> = async ({ response }) => {
 	const links = response.stats.socialMedia?.links;
 	return (
@@ -29,7 +40,7 @@ const PlayerExtraInfo: React.FC<PlayerExtraInfoProps> = async ({ response }) => 
 							const iconPath = socials[socialKey];
 							if (!iconPath) return null;
 							return (
-								<a key={social} href={links[socialKey]}>
+								<a key={social} href={linkPrefixes[socialKey] + links[socialKey]}>
 									<Image
 										src={iconPath.startsWith("/") ? iconPath : `/${iconPath}`}
 										alt={`${social} icon`}

--- a/swtools/app/components/player/PlayerOverallStats.tsx
+++ b/swtools/app/components/player/PlayerOverallStats.tsx
@@ -30,7 +30,15 @@ const PlayerOverallStats: React.FC<PlayerOverallStatsProps> = ({ response }) => 
 					</tr>
 					<tr>
 						<td style={{ width: "50%" }}>WLR</td>
-						<td>{stats.losses === 0 ? "∞" : ((stats.wins ?? 0) / (stats.losses ?? 0)).toFixed(3)}</td>
+						<td>
+							{stats.losses === 0 ? (
+								"∞"
+							) : (
+								<span className={((stats.wins ?? 0) / (stats.losses ?? 0)) > 1 ? "text-green-600" : ""}>
+									{((stats.wins ?? 0) / (stats.losses ?? 0)).toFixed(3)}
+								</span>
+							)}
+						</td>
 					</tr>
 					<tr>
 						<td style={{ width: "50%" }}>Kills</td>
@@ -42,7 +50,15 @@ const PlayerOverallStats: React.FC<PlayerOverallStatsProps> = ({ response }) => 
 					</tr>
 					<tr>
 						<td style={{ width: "50%" }}>KDR</td>
-						<td>{stats.deaths === 0 ? "∞" : ((stats.kills ?? 0) / (stats.deaths ?? 0)).toFixed(3)}</td>
+						<td>
+							{stats.deaths === 0 ? (
+								"∞"
+							) : (
+								<span className={((stats.kills ?? 0) / (stats.deaths ?? 0)) > 5 ? "text-green-600" : ""}>
+									{((stats.kills ?? 0) / (stats.deaths ?? 0)).toFixed(3)}
+								</span>
+							)}
+						</td>
 					</tr>
 					<tr>
 						<td style={{ width: "50%" }}>Heads</td>

--- a/swtools/app/components/player/PlayerTitle.tsx
+++ b/swtools/app/components/player/PlayerTitle.tsx
@@ -133,7 +133,7 @@ const PlayerTitle: React.FC<PlayerTitleProps> = ({ playerName, response }) => {
 					/>
 				</div>
 				<div className="text-xl font-montserrat justify-between lg:flex">
-					<div className="flex items-center gap-2 text-sm lg:text-lg">
+					<div className="items-center gap-2 text-lg hidden lg:flex">
 						{nationality && (
 							<span
 								dangerouslySetInnerHTML={{

--- a/swtools/app/components/player/tabs/GrimReaper.tsx
+++ b/swtools/app/components/player/tabs/GrimReaper.tsx
@@ -3,8 +3,8 @@ import React, { useEffect, useState } from "react";
 
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import DescentGUI from "./reaper/DescentGUI";
-import { calculateOpalsSpent, combineDescentData, fetcher } from "@/app/utils/Utils";
-import { LoaderCircle } from "lucide-react";
+import { calcLevel, calculateOpalsSpent, combineDescentData, fetcher } from "@/app/utils/Utils";
+import { Check, LoaderCircle, X } from "lucide-react";
 import { DescentMap } from "@/app/types/DescentMap";
 import Title from "../../universal/Title";
 import SoulUpgrades from "./reaper/SoulUpgrades";
@@ -70,6 +70,9 @@ const GrimReaper: React.FC<OverallResponse> = (response) => {
 						<div className="w-full lg:w-1/2 h-100rem bg-content py-3 px-4 flex flex-col gap-2 items-center rounded-2xl">
 							<h2 className="font-semibold flex items-center flex-col justify-center text-center">
 								<Title color="text-blue-400">Angel&apos;s Descent</Title>
+								<span className="flex flex-row gap-2">Eligibility: ({Math.floor(calcLevel(response.stats.skywars_experience ?? 0))}/25)
+									{Math.floor(calcLevel(response.stats.skywars_experience ?? 0)) >= 25 ? <Check className="text-green-500" /> : <X className="text-red-500" />}
+								</span>
 								<span className="text-base">
 									Hover over upgrades for details<br></br> Descent is as it appears on Hypixel
 								</span>

--- a/swtools/app/components/player/tabs/Table.tsx
+++ b/swtools/app/components/player/tabs/Table.tsx
@@ -1,11 +1,20 @@
-import React from "react";
-import TabContent from "./TabContent";
 import { OverallResponse } from "@/app/types/OverallResponse";
+import TabContent from "./TabContent";
 
 const Table: React.FC<OverallResponse> = (response) => {
 	const getWLR = (wins: number, losses: number) => {
 		if (losses === 0) return wins > 0 ? "∞" : "0.00";
 		return (wins / losses).toFixed(2);
+	};
+
+	const wlrClass = (wins: number, losses: number) => {
+		const wlr = losses === 0 ? (wins > 0 ? Infinity : 0) : wins / losses;
+		return wlr > 1 ? "text-green-600" : "";
+	};
+
+	const kdrClass = (kills: number, deaths: number) => {
+		const kdr = deaths === 0 ? (kills > 0 ? Infinity : 0) : kills / deaths;
+		return kdr > 5 ? "text-green-600" : "";
 	};
 
 	return (
@@ -25,49 +34,64 @@ const Table: React.FC<OverallResponse> = (response) => {
 							<td>Overall</td>
 							<td>{response.stats.wins?.toLocaleString()}</td>
 							<td>{response.stats.losses?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.wins ?? 0, response.stats.losses ?? 0).toLocaleString()}</td>
+							<td className={wlrClass(response.stats.wins ?? 0, response.stats.losses ?? 0)}>
+								{getWLR(response.stats.wins ?? 0, response.stats.losses ?? 0).toLocaleString()}
+							</td>
 						</tr>
 						<tr className="border-b-1 border-white">
 							<td>Solo</td>
 							<td>{response.stats.wins_solo?.toLocaleString()}</td>
 							<td>{response.stats.losses_solo?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.wins_solo ?? 0, response.stats.losses_solo ?? 0).toLocaleString()}</td>
+							<td className={wlrClass(response.stats.wins_solo ?? 0, response.stats.losses_solo ?? 0)}>
+								{getWLR(response.stats.wins_solo ?? 0, response.stats.losses_solo ?? 0).toLocaleString()}
+							</td>
 						</tr>
 						<tr className="border-b-1 border-white">
 							<td>Solo Normal</td>
 							<td>{response.stats.wins_solo_normal?.toLocaleString()}</td>
 							<td>{response.stats.losses_solo_normal?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.wins_solo_normal ?? 0, response.stats.losses_solo_normal ?? 0).toLocaleString()}</td>
+							<td className={wlrClass(response.stats.wins_solo_normal ?? 0, response.stats.losses_solo_normal ?? 0)}>
+								{getWLR(response.stats.wins_solo_normal ?? 0, response.stats.losses_solo_normal ?? 0).toLocaleString()}
+							</td>
 						</tr>
 						<tr className="border-b-2 border-white">
 							<td>Solo Insane</td>
 							<td>{response.stats.wins_solo_insane?.toLocaleString()}</td>
 							<td>{response.stats.losses_solo_insane?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.wins_solo_insane ?? 0, response.stats.losses_solo_insane ?? 0).toLocaleString()}</td>
+							<td className={wlrClass(response.stats.wins_solo_insane ?? 0, response.stats.losses_solo_insane ?? 0)}>
+								{getWLR(response.stats.wins_solo_insane ?? 0, response.stats.losses_solo_insane ?? 0).toLocaleString()}
+							</td>
 						</tr>
 						<tr className="border-b-1 border-white">
 							<td>Teams</td>
 							<td>{response.stats.wins_team?.toLocaleString()}</td>
 							<td>{response.stats.losses_team?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.wins_team ?? 0, response.stats.losses_team ?? 0).toLocaleString()}</td>
+							<td className={wlrClass(response.stats.wins_team ?? 0, response.stats.losses_team ?? 0)}>
+								{getWLR(response.stats.wins_team ?? 0, response.stats.losses_team ?? 0).toLocaleString()}
+							</td>
 						</tr>
 						<tr className="border-b-1 border-white">
 							<td>Teams Normal</td>
 							<td>{response.stats.wins_team_normal?.toLocaleString()}</td>
 							<td>{response.stats.losses_team_normal?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.wins_team_normal ?? 0, response.stats.losses_team_normal ?? 0).toLocaleString()}</td>
+							<td className={wlrClass(response.stats.wins_team_normal ?? 0, response.stats.losses_team_normal ?? 0)}>
+								{getWLR(response.stats.wins_team_normal ?? 0, response.stats.losses_team_normal ?? 0).toLocaleString()}
+							</td>
 						</tr>
 						<tr className="border-b-2 border-white">
 							<td>Teams Insane</td>
 							<td>{response.stats.wins_team_insane?.toLocaleString()}</td>
 							<td>{response.stats.losses_team_insane?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.wins_team_insane ?? 0, response.stats.losses_team_insane ?? 0).toLocaleString()}</td>
+							<td className={wlrClass(response.stats.wins_team_insane ?? 0, response.stats.losses_team_insane ?? 0)}>
+								{getWLR(response.stats.wins_team_insane ?? 0, response.stats.losses_team_insane ?? 0).toLocaleString()}
+							</td>
+							
 						</tr>
 						<tr className="border-b-1 border-white">
 							<td>Mini</td>
 							<td>{(response.stats.wins_mini ?? 0).toLocaleString()}</td>
 							<td>{(response.stats.games_mini ?? 0) - (response.stats.wins_mini ?? 0)}</td>
-							<td>
+							<td className={wlrClass(response.stats.wins_mini ?? 0, (response.stats.games_mini ?? 0) - (response.stats.wins_mini ?? 0))}>
 								{getWLR(response.stats.wins_mini ?? 0, (response.stats.games_mini ?? 0) - (response.stats.wins_mini ?? 0))}
 							</td>
 						</tr>
@@ -75,7 +99,7 @@ const Table: React.FC<OverallResponse> = (response) => {
 							<td>Lab</td>
 							<td>{(response.stats.wins_lab ?? 0).toLocaleString()}</td>
 							<td>{(response.stats.losses_lab)}</td>
-							<td>
+							<td className={wlrClass(response.stats.wins_lab ?? 0, response.stats.losses_lab ?? 0)}>
 								{getWLR(response.stats.wins_lab ?? 0, response.stats.losses_lab ?? 0).toLocaleString()}
 							</td>
 						</tr>
@@ -96,19 +120,23 @@ const Table: React.FC<OverallResponse> = (response) => {
 							<td className="inline lg:hidden">Overall</td>
 							<td>{response.stats.kills?.toLocaleString()}</td>
 							<td>{response.stats.deaths?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.kills ?? 0, response.stats.deaths ?? 0).toLocaleString()}</td>
+							<td className={kdrClass(response.stats.kills ?? 0, response.stats.deaths ?? 0)}>
+								{getWLR(response.stats.kills ?? 0, response.stats.deaths ?? 0).toLocaleString()}
+							</td>
 						</tr>
 						<tr className="border-b-1 border-white">
 							<td className="inline lg:hidden">Solo</td>
 							<td>{response.stats.kills_solo?.toLocaleString()}</td>
 							<td>{response.stats.deaths_solo?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.kills_solo ?? 0, response.stats.deaths_solo ?? 0).toLocaleString()}</td>
+							<td className={kdrClass(response.stats.kills_solo ?? 0, response.stats.deaths_solo ?? 0)}>
+								{getWLR(response.stats.kills_solo ?? 0, response.stats.deaths_solo ?? 0).toLocaleString()}
+							</td>
 						</tr>
 						<tr className="border-b-1 border-white">
 							<td className="inline lg:hidden">Solo Normal</td>
 							<td>{response.stats.kills_solo_normal?.toLocaleString()}</td>
 							<td>{response.stats.deaths_solo_normal?.toLocaleString()}</td>
-							<td>
+							<td className={kdrClass(response.stats.kills_solo_normal ?? 0, response.stats.deaths_solo_normal ?? 0)}>
 								{getWLR(response.stats.kills_solo_normal ?? 0, response.stats.deaths_solo_normal ?? 0).toLocaleString()}
 							</td>
 						</tr>
@@ -116,7 +144,7 @@ const Table: React.FC<OverallResponse> = (response) => {
 							<td className="inline lg:hidden">Solo Insane</td>
 							<td>{response.stats.kills_solo_insane?.toLocaleString()}</td>
 							<td>{response.stats.deaths_solo_insane?.toLocaleString()}</td>
-							<td>
+							<td className={kdrClass(response.stats.kills_solo_insane ?? 0, response.stats.deaths_solo_insane ?? 0)}>
 								{getWLR(response.stats.kills_solo_insane ?? 0, response.stats.deaths_solo_insane ?? 0).toLocaleString()}
 							</td>
 						</tr>
@@ -124,13 +152,15 @@ const Table: React.FC<OverallResponse> = (response) => {
 							<td className="inline lg:hidden">Teams</td>
 							<td>{response.stats.kills_team?.toLocaleString()}</td>
 							<td>{response.stats.deaths_team?.toLocaleString()}</td>
-							<td>{getWLR(response.stats.kills_team ?? 0, response.stats.deaths_team ?? 0).toLocaleString()}</td>
+							<td className={kdrClass(response.stats.kills_team ?? 0, response.stats.deaths_team ?? 0)}>
+								{getWLR(response.stats.kills_team ?? 0, response.stats.deaths_team ?? 0).toLocaleString()}
+							</td>
 						</tr>
 						<tr className="border-b-1 border-white">
 							<td className="inline lg:hidden">Teams Normal</td>
 							<td>{response.stats.kills_team_normal?.toLocaleString()}</td>
 							<td>{response.stats.deaths_team_normal?.toLocaleString()}</td>
-							<td>
+							<td className={kdrClass(response.stats.kills_team_normal ?? 0, response.stats.deaths_team_normal ?? 0)}>
 								{getWLR(response.stats.kills_team_normal ?? 0, response.stats.deaths_team_normal ?? 0).toLocaleString()}
 							</td>
 						</tr>
@@ -138,7 +168,7 @@ const Table: React.FC<OverallResponse> = (response) => {
 							<td className="inline lg:hidden">Teams Insane</td>
 							<td>{response.stats.kills_team_insane?.toLocaleString()}</td>
 							<td>{response.stats.deaths_team_insane?.toLocaleString()}</td>
-							<td>
+							<td className={kdrClass(response.stats.kills_team_insane ?? 0, response.stats.deaths_team_insane ?? 0)}>
 								{getWLR(response.stats.kills_team_insane ?? 0, response.stats.deaths_team_insane ?? 0).toLocaleString()}
 							</td>
 						</tr>
@@ -146,7 +176,7 @@ const Table: React.FC<OverallResponse> = (response) => {
 							<td className="inline lg:hidden">Mini</td>
 							<td>{response.stats.kills_mini ?? "0".toLocaleString()}</td>
 							<td>{(response.stats.games_mini ?? 0) - (response.stats.wins_mini ?? 0)}</td>
-							<td>
+							<td className={kdrClass(response.stats.kills_mini ?? 0, (response.stats.games_mini ?? 0) - (response.stats.wins_mini ?? 0))}>
 								{getWLR(response.stats.kills_mini ?? 0, (response.stats.games_mini ?? 0) - (response.stats.wins_mini ?? 0))}
 							</td>
 						</tr>
@@ -154,7 +184,7 @@ const Table: React.FC<OverallResponse> = (response) => {
 							<td className="inline lg:hidden">Lab</td>
 							<td>{response.stats.kills_lab?.toLocaleString()}</td>
 							<td>{response.stats.deaths_lab?.toLocaleString()}</td>
-							<td>
+							<td className={kdrClass(response.stats.kills_lab ?? 0, response.stats.deaths_lab ?? 0)}>
 								{getWLR(response.stats.kills_lab ?? 0, response.stats.deaths_lab ?? 0).toLocaleString()}
 							</td>
 						</tr>
@@ -163,6 +193,6 @@ const Table: React.FC<OverallResponse> = (response) => {
 			</div>
 		</TabContent>
 	);
-};
+}
 
 export default Table;

--- a/swtools/app/components/player/tabs/kits/KitPrestigeCard.tsx
+++ b/swtools/app/components/player/tabs/kits/KitPrestigeCard.tsx
@@ -40,9 +40,10 @@ const KitPrestigeCard: React.FC<KitPrestigeCardProps> = ({ kitName, stats, curre
 	const [customXpPerHour, setCustomXpPerHour] = React.useState(initialXpPerHour);
 
 	let glitched = false;
-	// TODO find a better way at detecting glitched kits via lucky blocks
 	if (kitName.includes("team")) {
-		if (initialXpPerHour > 15000) {
+		const xp = stats.xp ?? 0;
+		const kills = stats.kills ?? 0;
+		if (kills * 25 < xp) {
 			glitched = true;
 		}
 	}
@@ -92,7 +93,11 @@ const KitPrestigeCard: React.FC<KitPrestigeCardProps> = ({ kitName, stats, curre
 		<div
 			className={
 				`bg-gray-900 rounded-xl p-4 w-75 h-${maxHeight} overflow-hidden  cursor-pointer shadow-lg border ` +
-				(maxed ? "enchanted border-amber-400" : glitched ? "border-red-500 bg-red-900/50" : "border-gray-700")
+				(glitched
+					? "border-red-500 bg-red-900/50"
+					: maxed
+					? "enchanted border-amber-400"
+					: "border-gray-700")
 			}
 			onClick={() => toggleHeight()}
 		>

--- a/swtools/app/components/player/tabs/kits/KitPrestiges.tsx
+++ b/swtools/app/components/player/tabs/kits/KitPrestiges.tsx
@@ -23,8 +23,8 @@ const KitPrestiges: React.FC< Record<string, number|undefined>> = (stats) => {
 		return (xp / nextPrestige.minXp) % 1;
 	}
 	function closestToOpal(xp: number, nextPrestige: KitPrestigeInfo): number {
-		if (nextPrestige.minXp === 0) return -1;
-		if (nextPrestige.key < 5) return -1;
+		if (nextPrestige.minXp === 0) return -99;
+		if (nextPrestige.key < 4) return -((7 - nextPrestige.key) - (1 / (nextPrestige.minXp / xp))); // wow this is stupid but it works
 		return (xp / nextPrestige.minXp) % 1;
 
 	}

--- a/swtools/app/components/start/PatreonPlayerList.tsx
+++ b/swtools/app/components/start/PatreonPlayerList.tsx
@@ -31,40 +31,37 @@ const PatreonPlayerList = () => {
 				{!isLoading &&
 					!error &&
 					data &&
-					data.supporters.map((supporter, index) => (
-						<a
-							href={`/player/${supporter.name}/stats/table`}
-							key={index}
-							className="flex items-center gap-3 lg:gap-4 bg-content rounded-md p-1 lg:p-2 w-full text-xl animate-press cursor-pointer enchanted"
-						>
-							{supporter.mc_account ? (
+					data.supporters.map((supporter, index) => {
+						if (!supporter.mc_account) return null;
+						return (
+							<a
+								href={`/player/${supporter.name}/stats/table`}
+								key={index}
+								className="flex items-center gap-3 lg:gap-4 bg-content rounded-md p-1 lg:p-2 w-full text-xl animate-press cursor-pointer enchanted"
+							>
 								<Image
 									src={`https://www.mc-heads.net/avatar/${supporter.mc_account}`}
-									alt={supporter.mc_account}
+									alt={supporter.mc_account ?? "Minecraft avatar"}
 									width={40}
 									height={40}
 									className="rounded"
 								/>
-							) : (
-								<div className="w-10 h-10 flex items-center justify-center bg-gray-200 rounded">
-									<span className="text-xl">?</span>
+								<div className="min-w-0">
+									<div className="font-semibold truncate max-w-[225px] flex gap-2 items-center">
+										<span className="truncate max-w-[190px]">{supporter.name ?? "Unknown"}</span>
+										{
+											<span
+												dangerouslySetInnerHTML={{
+													__html: twemoji.parse(supporter.emoji ?? "", { folder: "svg", ext: ".svg" }),
+												}}
+												style={{ width: 28, height: 28, display: "inline-block" }}
+											/>
+										}
+									</div>
 								</div>
-							)}
-							<div className="min-w-0">
-								<div className="font-semibold truncate max-w-[225px] flex gap-2 items-center">
-									<span className="truncate max-w-[190px]">{supporter.name ?? "Unknown"}</span>
-									{
-										<span
-											dangerouslySetInnerHTML={{
-												__html: twemoji.parse(supporter.emoji ?? "", { folder: "svg", ext: ".svg" }),
-											}}
-											style={{ width: 28, height: 28, display: "inline-block" }}
-										/>
-									}
-								</div>
-							</div>
-						</a>
-					))}
+							</a>
+						);
+					})}
 			</div>
 		</>
 	);

--- a/swtools/app/page.tsx
+++ b/swtools/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
 				</div>
 				<div className="rounded-lg px-4 lg:px-8">
 					<h2 className="text-2xl font-bold mb-1 flex flex-row gap-4">
-						Patreon Supporters
+						Supporters
 						<Tooltip title="Subscribe to Patreon to get an emoji and a spot right here!">
 							<CircleQuestionMark className="cursor-help" />
 						</Tooltip>

--- a/swtools/app/player/[playerName]/calculate/page.tsx
+++ b/swtools/app/player/[playerName]/calculate/page.tsx
@@ -157,13 +157,23 @@ export default function CalculatePage() {
 						<div id="selectionOptions" className="flex flex-col gap-2 mb-4">
 							<div className="flex gap-2 justify-center mb-2 flex-wrap w-100">
 								{[
-									{ label: "Last 7", value: 7 },
-									{ label: "Last 14", value: 14 },
-									{ label: "Last 21", value: 21, disabled: disabled },
-									{ label: "Past 7 days", value: "past7days" },
-									{ label: "Past 14 days", value: "past14days" },
+									{ label: "Last 7", value: 7, title: "Auto-select the latest 7 snapshots" },
+									{ label: "Last 14", value: 14, title: "Auto-select the latest 14 snapshots" },
+									{
+										label: "Last 21",
+										value: 21,
+										disabled: disabled,
+										title: "Auto-select the latest 21 snapshots. Only available when logged in.",
+									},
+									{ label: "Past 7 days", value: "past7days", title: "Select all snapshots of the past 7 days" },
+									{ label: "Past 14 days", value: "past14days", title: "Select all snapshots of the past 14 days" },
+									{
+										label: "14 overall spread",
+										value: "overall14",
+										title: "Select 14 snapshots, spread from the first ever to most recent",
+									},
 								].map((opt) => (
-									<Tooltip key={opt.value} title={opt.disabled ? "Log in to be able to use more than 14 snapshots!" : ""}>
+									<Tooltip key={opt.value} title={opt.title} placement="top">
 										<span>
 											<button
 												className={`px-4 py-2 rounded-xl font-semibold border animate-press ${
@@ -184,6 +194,17 @@ export default function CalculatePage() {
 																allSnapshots?.filter((s) => s.queried >= daysAgo).map((s) => s.queried) ??
 																[];
 															setSelectedSnapshots(filtered);
+														} else if (opt.value === "overall14") {
+															if (allSnapshots && allSnapshots.length >= 14) {
+																const step = (allSnapshots.length - 1) / 13;
+																const spread = Array.from(
+																	{ length: 14 },
+																	(_, i) => allSnapshots[Math.round(i * step)].queried
+																);
+																setSelectedSnapshots(spread);
+															} else {
+																setSelectedSnapshots(allSnapshots?.map((s) => s.queried) ?? []);
+															}
 														} else {
 															setSelectedSnapshots(
 																allSnapshots?.slice(0, Number(opt.value)).map((s) => s.queried) ?? []
@@ -204,7 +225,7 @@ export default function CalculatePage() {
 									setCustomDatePickerOpen(!customDatePickerOpen);
 								}}
 							>
-								Open custom picker
+								{customDatePickerOpen ? "Close Custom Date Picker" : "Open Custom Date Picker"}
 							</div>
 						</div>
 						{customDatePickerOpen && (
@@ -219,7 +240,7 @@ export default function CalculatePage() {
 							</>
 						)}
 						<div className="mb-2 underline">
-							<Tooltip title={selectedSnapshots.map((s) => new Date(s).toLocaleDateString()).join(", ")}>
+							<Tooltip title={selectedSnapshots.map((s) => new Date(s).toLocaleDateString()).join(", ")} placement="top">
 								<strong>
 									{selectedSnapshots.length === 0
 										? "No snapshots selected"
@@ -313,11 +334,13 @@ export default function CalculatePage() {
 							Calculate
 						</button>
 						{/* TODO fix unstateful state selectionErrors - then we can only show thius when selectionErrors > 0*/}
-						<div className={"errors mt-6 rounded-xl bg-red-300 p-2 text-red-900 font-semibold"}>
-							{selectionErrors.map((err, idx) => (
-								<p key={idx}>{err}</p>
-							))}
-						</div>
+						{selectionErrors.length >= 1 && (
+							<div className="errors mt-6 rounded-xl bg-red-300 p-2 text-red-900 font-semibold">
+								{selectionErrors.map((err, idx) => (
+									<p key={idx}>{err}</p>
+								))}
+							</div>
+						)}
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
* Kits include all keys, closest opal order

* Prestige tab fixes, Kit/Title layouts

* All Leaderboard kit keys

* e

* Closest Opal + better kit glitch check

* green stats

* Social fixes, title fix, angels descent minimum

* Calculate extra information in both view and result + fixes

* ESLint

* Patreon supporters on index page fix, profile cursor pointer

Patreon accounts that are not linked to MC accounts are not shown on front page now